### PR TITLE
Modularize-Reg-Checks

### DIFF
--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -85,6 +85,46 @@ function Get-RegistryValueType {
 
         $ValueType
 } # close Get-RegistryValueType
+
+function Get-RegistryValueData {
+    [CmdletBinding()]
+    param(
+        [string]$InputLine,
+        [string]$Rule )
+
+        if ($InputLine -LIKE "Value: *") {
+            $ValueData = ($strLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
+            ## todo: replace this with regex...list has grown
+            switch ($ValueData) {
+                '0x000000ff (255)' {$ValueData = '255'}
+                '0x00000004 (4)' {$ValueData = '4'}
+                '0x0000000f (15)' {$ValueData = '15'}
+                '0x0000000a (10)' {$ValueData = '10'}
+                '(blank)' {$ValueData = ''}
+                '0x20080000 (537395200)' {$ValueData = '537395200'}
+                '0x0000ea60 (60000)' {$ValueData = '60000'}
+                '0x20080000 (537395200)' {$ValueData = '53739520'}
+                '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
+                '0x00030000 (196608) (or greater)' {$ValueData = '196608'}
+                '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
+                '0x00000002 (2)' {$ValueData = '2'}
+                '0x00000384 (900)' {$ValueData = '900'}
+                '0x00000032 (50)' {$ValueData = '50'}
+                "0x00000064 (100)" {$ValueData = '100'}
+                "0x00008000 (32768)" {$ValueData = '32768'}
+                "0x00030000 (196608)" {$ValueData = '196608'}
+                "0x00008000 (32768)" {$ValueData = '32768'}
+                Default {}
+            }# close switch
+
+        If ( [INT]$ValueData ) {
+            Write-Debug "The identified value type for $Rule : $ValueData" 
+        } Else {
+            Write-Debug "No identified value type for $Rule : $ValueData" 
+        }
+
+        $ValueData
+} # Close Get-RegistryValueData
   
 function New-DisaStigConfig {
     <#
@@ -188,33 +228,10 @@ function New-DisaStigConfig {
                         $ValueType = Get-RegistryValueType -InputLine $strLine -Rule $($STIG.Ruleid)
                     }
 
-                    ## find the -ValueData  portion of our audit
-                    elseif ($strLine -LIKE "Value: *") {
-                        $ValueData = ($strLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
-                        ## todo: replace this with regex...list has grown
-                        switch ($ValueData) {
-                            '0x000000ff (255)' {$ValueData = '255'}
-                            '0x00000004 (4)' {$ValueData = '4'}
-                            '0x0000000f (15)' {$ValueData = '15'}
-                            '0x0000000a (10)' {$ValueData = '10'}
-                            '(blank)' {$ValueData = ''}
-                            '0x20080000 (537395200)' {$ValueData = '537395200'}
-                            '0x0000ea60 (60000)' {$ValueData = '60000'}
-                            '0x20080000 (537395200)' {$ValueData = '53739520'}
-                            '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
-                            '0x00030000 (196608) (or greater)' {$ValueData = '196608'}
-                            '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
-                            '0x00000002 (2)' {$ValueData = '2'}
-                            '0x00000384 (900)' {$ValueData = '900'}
-                            '0x00000032 (50)' {$ValueData = '50'}
-                            "0x00000064 (100)" {$ValueData = '100'}
-                            "0x00008000 (32768)" {$ValueData = '32768'}
-                            "0x00030000 (196608)" {$ValueData = '196608'}
-                            "0x00008000 (32768)" {$ValueData = '32768'}
-                            Default {}
-                        }# close switch
-                        Write-Debug "The identified value data for $($STIG.Ruleid) : $ValueData"   
-                    } #close else-if chain
+                    If ($ValueData -eq $Null) {
+                        $ValueData = Get-RegistryValueData -InputLine $strLine -Rule $($STIG.Ruleid)
+                    }
+ 
                 }# close foreach line in lines
             ## remove any escaping characters for the comments and description...not important to maintain
             $RuleHeader = "$($STIG.RuleID) : $($STIG.Severity) (Registry)"

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -114,7 +114,7 @@ function Get-RegistryValueData {
                 "0x00008000 (32768)" {$ValueData = '32768'}
                 "0x00030000 (196608)" {$ValueData = '196608'}
                 "0x00008000 (32768)" {$ValueData = '32768'}
-                Default {}
+                default { $null }
             }# close switch
 
         If ( [INT]$ValueData ) {

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -96,26 +96,11 @@ function Get-RegistryValueData {
             $ValueData = ($strLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
             ## todo: replace this with regex...list has grown
             switch ($ValueData) {
-                '0x000000ff (255)' {$ValueData = '255'}
-                '0x00000004 (4)' {$ValueData = '4'}
-                '0x0000000f (15)' {$ValueData = '15'}
-                '0x0000000a (10)' {$ValueData = '10'}
-                '(blank)' {$ValueData = ''}
-                '0x20080000 (537395200)' {$ValueData = '537395200'}
-                '0x0000ea60 (60000)' {$ValueData = '60000'}
-                '0x20080000 (537395200)' {$ValueData = '53739520'}
-                '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
-                '0x00030000 (196608) (or greater)' {$ValueData = '196608'}
-                '0x00008000 (32768) (or greater)' {$ValueData = '32768'}
-                '0x00000002 (2)' {$ValueData = '2'}
-                '0x00000384 (900)' {$ValueData = '900'}
-                '0x00000032 (50)' {$ValueData = '50'}
-                "0x00000064 (100)" {$ValueData = '100'}
-                "0x00008000 (32768)" {$ValueData = '32768'}
-                "0x00030000 (196608)" {$ValueData = '196608'}
-                "0x00008000 (32768)" {$ValueData = '32768'}
+                "0x\w{8}" { $ValueData = $( [Convert]::ToInt32($Matches[0],16) ) }
                 Default { $null }
             } # close switch
+            
+            $ValueData
         }
 
         If ( [INT]$ValueData ) {
@@ -332,7 +317,7 @@ function New-DisaStigConfig {
 
             Write-Host "Unused Rules: "
             $UnusedRules
-        }  
+        }   
 
     }# close END
 }# close New-DisaStigConfig

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -105,6 +105,10 @@ function New-DisaStigConfig {
                     
                     If ($Hive -ne $Null) {
                         $Hive = Get-RegistryHive $strLine
+                        If ($Hive) {
+                            Write-Debug "The identified registry path for $($STIG.Ruleid) : $Hive"
+                        } Else {
+                            Write-Debug "No identified registry path for $($STIG.Ruleid)."
                     }
                     
                     ## find the registry path and put together with hive

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -109,6 +109,7 @@ function New-DisaStigConfig {
                             Write-Debug "The identified registry path for $($STIG.Ruleid) : $Hive"
                         } Else {
                             Write-Debug "No identified registry path for $($STIG.Ruleid)."
+                        }
                     }
                     
                     ## find the registry path and put together with hive

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -138,7 +138,16 @@ function New-DisaStigConfig {
                         $Path = Get-RegistryPath -InputLine $strLine -RuleId $($STIG.Ruleid)
                     }
 
-                    $Key = $Hive + $Path
+                    # Build Key
+                    If ( $Key -eq $Null ) {
+                        If ( ($Hive) -and ($Path) ) {
+                            $Key = $Hive + $Path
+                            Write-Debug "The identified key for $($STIG.Ruleid) : $Key"
+                        } Else {
+                            Write-Debug "No identified key for $($STIG.Ruleid)."
+                        }
+                    }
+                    
                     ## find the -ValueName portion of our audit
                     elseif ($strLine -LIKE "Value Name: *") {
                         $ValueName = ($strLine -replace "Value Name: ", "").Trim()  

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -92,25 +92,31 @@ function Get-RegistryValueData {
         [string]$InputLine,
         [string]$Rule )
 
-        if ($InputLine -LIKE "Value: *") {
-            $ValueData = ($strLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
-            ## todo: replace this with regex...list has grown
-            switch ($ValueData) {
-                "0x\w{8}" { $ValueData = $( [Convert]::ToInt32($Matches[0],16) ) }
-                Default { $null }
-            } # close switch
-            
-            $ValueData
-        }
-
-        If ( [INT]$ValueData ) {
-            Write-Debug "The identified value type for $Rule : $ValueData" 
+        Write-Verbose "InputLine: $InputLine"
+        #$InputLine = ($InputLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
+        ## todo: replace this with regex...list has grown
+        $ValueData = switch -regex ($InputLine) {
+            "0x\w{8}" { $( [Convert]::ToInt32($Matches[0],16) ) }
+            "\d{1}" { $Matches[0] }
+            Default { $null }
+        } # close switch
+        
+        Try { 
+            $ValueData = [INT]$ValueData
+        } Catch { 
+            $ValueData = $Null
+        } 
+        
+        If ($ValueData) {
+            Write-Debug "The identified value type for $Rule : $ValueData"
+            Write-Verbose "The identified value type for $Rule : $ValueData"
         } Else {
-            Write-Debug "No identified value type for $Rule : $ValueData" 
+           Write-Debug "No identified value type for $Rule : $ValueData"
+           Write-Verbose "No identified value type for $Rule : $ValueData"
         }
 
         $ValueData
-} # Close Get-RegistryValueData
+} # close Get-RegistryValueData
   
 function New-DisaStigConfig {
     <#

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -237,13 +237,9 @@ function New-DisaStigConfig {
             ## remove any escaping characters for the comments and description...not important to maintain
             $RuleHeader = "$($STIG.RuleID) : $($STIG.Severity) (Registry)"
             $VulnsDetailsSanitized = $STIG.VulnerabilityDetails | Sanitize-String
+            }
 
-            ## create the DSC configuration based off the parsing of the CheckContent
-            $NewDscConfig = New-DSCRegistryConfig -RuleHeader $RuleHeader -RuleTitle $($STIG.RuleTitle) `
-                -Description $VulnsDetailsSanitized -RuleID $($STIG.RuleID) -ValueName $ValueName -ValueData $ValueData `
-                -Key $Key -ValueType $ValueType
-            $DscConfigCollection += $NewDscConfig
-            } elseif ($STIG.RuleID -notin $Exceptions) {
+            if ($STIG.RuleID -notin $Exceptions) {
                 $Lines = $($STIG.Check).Split("`n")
                 $CheckLines = ""
                 ## loop through each line of the the CheckContent
@@ -266,7 +262,7 @@ function New-DisaStigConfig {
                         Key = $Key
                         ValueType = $ValueType
                     }
-                    
+
                     $NewDscConfig = New-DSCRegistryConfig @NewDscRegistryConfigParameters
 
                     $DscConfigCollection += $NewDscConfig
@@ -290,7 +286,6 @@ function New-DisaStigConfig {
 "@
         $DSC | Out-File $outFile
     }# close END
-  
 }# close New-DisaStigConfig
 #TODO add console count of stigs processed vs reg and non-reg
 Export-ModuleMember -Function New-DisaStigConfig

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -24,21 +24,41 @@ function Get-RegistryPath {
     [CmdletBinding()]
     param(
         [string]$InputLine,
-        [string]$RuleId )
+        [string]$Rule )
 
     $RegPath = switch -wildcard ($strLine) {
-        "Registry Path: *" { $(($PSItem -replace "Registry Path: ", "").Trim()) }
+        "Registry Path: *" { $( ($PSItem -replace "Registry Path: ", "").Trim() ) }
         default { $null }
     }
     
     If ($Path) {
-        Write-Debug "The identified registry path for $RuleId) : $Path"
+        Write-Debug "The identified registry path for $Rule : $Path"
     } Else {
-        Write-Debug "No identified registry path for $RuleId)."
+        Write-Debug "No identified registry path for $Rule."
     }
 
     $RegPath
 } # close Get-RegistryPath
+
+function Get-RegistryValueName {
+    [CmdletBinding()]
+    param(
+        [string]$InputLine,
+        [string]$Rule )
+        
+        $ValueName = switch -wildcard ($strLine) {
+            "Value Name: *" { $( ($PSItem -replace "Value Name: ", "").Trim() ) }
+            default { $null }
+        }
+
+        If ($ValueName) {
+            Write-Debug "The identified value name for $Rule : $ValueName"
+        } Else {
+            Write-Debug "No identified value name for $Rule." 
+        }
+
+        $ValueName
+} # close Get-RegistryValueName
 
   
 function Get-RegTypeValue {
@@ -130,12 +150,12 @@ function New-DisaStigConfig {
                     ## find the registry hive
                     
                     If ($Hive -eq $Null) {
-                        $Hive = Get-RegistryHive -InputLine $strLine -RuleId $($STIG.Ruleid)
+                        $Hive = Get-RegistryHive -InputLine $strLine -Rule $($STIG.Ruleid)
                     }
                     
                     ## find the registry path
                     If ($Path -eq $Null) {
-                        $Path = Get-RegistryPath -InputLine $strLine -RuleId $($STIG.Ruleid)
+                        $Path = Get-RegistryPath -InputLine $strLine -Rule $($STIG.Ruleid)
                     }
 
                     # Build Key
@@ -147,12 +167,11 @@ function New-DisaStigConfig {
                             Write-Debug "No identified key for $($STIG.Ruleid)."
                         }
                     }
-                    
-                    ## find the -ValueName portion of our audit
-                    elseif ($strLine -LIKE "Value Name: *") {
-                        $ValueName = ($strLine -replace "Value Name: ", "").Trim()  
-                        Write-Debug "The identified value name for $($STIG.Ruleid) : $ValueName" 
+
+                    If ($ValueName -eq $Null) {
+                        $ValueName = Get-RegistryValueName -InputLine $strLine -Rule $($STIG.Ruleid)
                     }
+
                     ## find the -ValueType portion of our audit
                     elseif ($strLine -LIKE "*Type: *") {
                         $ValueTypeParse = $($strLine -replace "Type: ", "") -replace "Value ", ""

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -251,17 +251,19 @@ function New-DisaStigConfig {
 
             if ($STIG.RuleID -notin $Exceptions) {
                 $Lines = $($STIG.Check).Split("`n")
-                $CheckLines = ""
+                $CheckLines = @()
+                
                 ## loop through each line of the the CheckContent
                 foreach ($line in $Lines) {
-                                            ## eliminate any leading or trailing spaces
-                                            [string]$strLine = $line.Trim()
-                                            $CheckLines += $strLine
-                                            }#close foreach line in lines
-                    $RuleHeader = "$($STIG.RuleID) : $($STIG.Severity) (Policy)"
-                    $VulnsDetailsSanitized = $STIG.VulnerabilityDetails | Sanitize-String
+                    ## eliminate any leading or trailing spaces
+                    [string]$strLine = $line.Trim()
+                    $CheckLines += $strLine
+                } #close foreach line in lines
                     
-                $Abort = Switch ( $True ) {
+                $RuleHeader = "$($STIG.RuleID) : $($STIG.Severity) (Policy)"
+                $VulnsDetailsSanitized = $STIG.VulnerabilityDetails | Sanitize-String
+                    
+                $ShouldAbort = Switch ( $True ) {
                     { [String]::IsNullOrEmpty($RuleHeader) } { $true }
                     { [String]::IsNullOrEmpty($($STIG.RuleTitle)) } { $true }
                     { [String]::IsNullOrEmpty($VulnsDetailsSanitized) } { $true }
@@ -272,11 +274,12 @@ function New-DisaStigConfig {
                     { [String]::IsNullOrEmpty($ValueType) } { $true }
                     default { $False }
                 }
-                    If ( $Abort ) {
-                        Write-Verbose "$($STIG.RuleID): Something is null, not writing"
-                        If ($DisplayRules) { [Void]$UnusedRules.Add($($STIG.RuleID)) }
-                        Continue
-                    }
+                
+                If ( $ShouldAbort ) {
+                    Write-Verbose "$($STIG.RuleID): Something is null, not writing"
+                    If ($DisplayRules) { [Void]$UnusedRules.Add($($STIG.RuleID)) }
+                    Continue
+                }
 
                     ## create the DSC configuration based off the parsing of the CheckContent
                     $NewDscRegistryConfigParameters = @{

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -6,8 +6,8 @@ function Get-RegistryHive {
         [string]$RuleId )
     
     $Hive = switch -regex ($strLine) {
-        "HKEY_LOCAL_MACHINE" { "HKLM:" }
-        "HKEY_CURRENT_USER" { "HKCU:" }
+        "HKEY_LOCAL_MACHINE" { "HKLM:" ; Break }
+        "HKEY_CURRENT_USER" { "HKCU:" ; Break }
         default { $null }
     }
     
@@ -27,7 +27,7 @@ function Get-RegistryPath {
         [string]$Rule )
 
     $RegPath = switch -wildcard ($InputLine) {
-        "Registry Path: *" { $( ($PSItem -replace "Registry Path: ", "").Trim() ) }
+        "Registry Path: *" { $( ($PSItem -replace "Registry Path: ", "").Trim() ) ; Break }
         default { $null }
     }
     
@@ -47,7 +47,7 @@ function Get-RegistryValueName {
         [string]$Rule )
         
         $ValueName = switch -wildcard ($InputLine) {
-            "Value Name: *" { $( ($PSItem -replace "Value Name: ", "").Trim() ) }
+            "Value Name: *" { $( ($PSItem -replace "Value Name: ", "").Trim() ) ; Break }
             default { $null }
         }
 
@@ -68,12 +68,12 @@ function Get-RegistryValueType {
 
         If ($InputLine -like "*Type: *") {
             $ValueType = switch -regex ($InputLine) {
-                "REG_DWORD*" { "Dword" } 
-                "REG_SZ" { "String" }
-                "REG_BINARY" { "Binary" }
-                "REG_QWORD" { "Qword" }
-                "REG_MULTI_SZ" { "MultiString" }
-                "REG_EXPAND_SZ" { "ExpandString" }
+                "REG_DWORD*" { "Dword" ; Break } 
+                "REG_SZ" { "String" ; Break }
+                "REG_BINARY" { "Binary" ; Break }
+                "REG_QWORD" { "Qword" ; Break }
+                "REG_MULTI_SZ" { "MultiString" ; Break }
+                "REG_EXPAND_SZ" { "ExpandString" ; Break }
                 default { $null }
             }
         }
@@ -97,8 +97,8 @@ function Get-RegistryValueData {
             #$InputLine = ($InputLine -replace "Value: ", "" -replace "\(or less\)" -replace "\(or greater\)" -replace "\(Enabled\)").Trim()
             ## todo: replace this with regex...list has grown
             $ValueData = switch -regex ($InputLine) {
-                "0x\w{8}" { $( [Convert]::ToInt32($Matches[0],16) ) }
-                "\d{1}" { $Matches[0] }
+                "0x\w{8}" { $( [Convert]::ToInt32($Matches[0],16) ) ; Break }
+                "\d{1}" { $Matches[0] ; Break }
                 Default { $null }
             } # close switch
         }

--- a/PowerStig/PowerStig.psm1
+++ b/PowerStig/PowerStig.psm1
@@ -26,7 +26,7 @@ function Get-RegistryPath {
         [string]$InputLine,
         [string]$Rule )
 
-    $RegPath = switch -wildcard ($strLine) {
+    $RegPath = switch -wildcard ($InputLine) {
         "Registry Path: *" { $( ($PSItem -replace "Registry Path: ", "").Trim() ) }
         default { $null }
     }
@@ -46,7 +46,7 @@ function Get-RegistryValueName {
         [string]$InputLine,
         [string]$Rule )
         
-        $ValueName = switch -wildcard ($strLine) {
+        $ValueName = switch -wildcard ($InputLine) {
             "Value Name: *" { $( ($PSItem -replace "Value Name: ", "").Trim() ) }
             default { $null }
         }
@@ -66,8 +66,8 @@ function Get-RegistryValueType {
         [string]$InputLine,
         [string]$Rule )
 
-        If ($strLine -like "*Type: *") {
-            $ValueType = switch -wildcard ($strLine) {
+        If ($InputLine -like "*Type: *") {
+            $ValueType = switch -wildcard ($InputLine) {
                 "*REG_DWORD*" {"Dword"} 
                 "*REG_SZ" {"String"}
                 "*REG_BINARY" {"Binary"}


### PR DESCRIPTION
Modularized / created functions for all of the Registry checks.

Added logic to ensure you don't write blank data into the required fields in the DSC File.

Added -DisplayRules param to show which rules were sucessfully parsed and which were not.

Deleted 'New-DSCPolicyConfig' - you weren't actually using it, but it was causing you to output blank entries into the DSC file.